### PR TITLE
feat: Nginx service statistics

### DIFF
--- a/.ddev/config.webserver.yaml
+++ b/.ddev/config.webserver.yaml
@@ -1,0 +1,8 @@
+# Expose port 8080
+# Visit `:8080/stub_status` to see Nginx server statistics.
+# @See `.ddev/nginx_full/stub_status.conf`
+web_extra_exposed_ports:
+  - name: webserver
+    container_port: 8080
+    http_port: 8081
+    https_port: 8080

--- a/.ddev/nginx_full/stub_status.conf
+++ b/.ddev/nginx_full/stub_status.conf
@@ -1,0 +1,11 @@
+server {
+    listen 8080 default_server;
+
+    location /stub_status {
+        stub_status;
+        allow 127.0.0.1;   # allow localhost
+        allow 172.0.0.0/8; # allow other Docker containers
+        allow ::1;         # allow IPv6 localhost
+        deny all;          # deny everyone else
+    }
+}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,39 @@
 ## Overview
 
 This project is a basic DDEV nginx webserver setup.
+
+## Service status
+
+1. Ensure `stub_status` module is enabled.
+
+    ```shell
+    nginx -V 2>&1 | grep -o with-http_stub_status_module
+    ```
+
+2. Configure endpoint.
+
+    ```conf
+    server {
+        listen 8080 default_server;
+
+        location /stub_status {
+            stub_status;
+            allow 127.0.0.1;   # allow localhost
+            allow 172.0.0.0/8; # allow other Docker containers
+            allow ::1;         # allow IPv6 localhost
+            deny all;          # deny everyone else
+        }
+    }
+    ````
+
+3. Access endpoint.
+
+    ```shell
+    $ ddev exec curl web:8080/stub_status
+    Active connections: 1
+    server accepts handled requests
+    2 2 2
+    Reading: 0 Writing: 1 Waiting: 0
+    ```
+
+4. Access `:8080/stub_status` to view in browser.


### PR DESCRIPTION
This PR enables the `stub_status` module in Nginx and configures a `/stub_status` endpoint, accessible via `http://<ddev-site-name>:8080/stub_status` (or `https://<ddev-site-name>:8080/stub_status`).

**Changes:**

*   **`.ddev/config.webserver.yaml`:**  Adds configuration to expose port 8080 from the webserver container, mapping it to ports 8081 (HTTP) and 8080 (HTTPS) on the host machine.  This allows access to the `stub_status` page from the host.
*   **`.ddev/nginx_full/stub_status.conf`:** Creates a new Nginx configuration file that defines a virtual host listening on port 8080 and configures the `/stub_status` location.  It includes access restrictions allowing only localhost and other Docker containers to access the status page.
*   **`README.md`:**  Updates the README with instructions on how to verify the `stub_status` module is enabled, how the endpoint is configured, and how to access it.  It also includes an example of the output you should expect.

**Manual Testing Steps:**

1.  **Apply the changes:** Checkout this branch and pull the changes.
2.  **Start/Restart DDEV:** `ddev restart`
3.  **Verify Nginx Module:** Execute `ddev exec "nginx -V 2>&1 | grep -o with-http_stub_status_module"` within the DDEV environment. The output should include `with-http_stub_status_module`.
4.  **Access the Endpoint:** Open your browser and navigate to `http://<ddev-site-name>:8080/stub_status` (replace `<ddev-site-name>` with your DDEV project's name, usually `<projectname>.ddev.site`).
5.  **Inspect the Output:** You should see a plain text page with Nginx server statistics, including active connections, accepts, handled requests, and reading/writing/waiting connections.
6.  **Test from within the container:** Run `ddev exec curl web:8080/stub_status`.  This should also return the status information.

**Benefits:**

*   Provides a simple way to monitor Nginx's status and performance.
*   Helps in identifying potential bottlenecks or issues with the web server.
*   Easy to configure and use within the DDEV environment.

**Considerations:**

*   The `stub_status` module provides basic information.  For more advanced monitoring, consider using a dedicated monitoring tool like Prometheus or Grafana.
*   The access restrictions are currently set to allow localhost and other Docker containers.  Adjust these restrictions as needed for your specific environment.